### PR TITLE
Update re.sonny.Tangram.desktop

### DIFF
--- a/data/re.sonny.Tangram.desktop
+++ b/data/re.sonny.Tangram.desktop
@@ -10,3 +10,4 @@ X-GNOME-UsesNotifications=true
 Icon=re.sonny.Tangram
 DBusActivatable=true
 Keywords=Franz;Ferdi;Rambox;Wavebox;Station;
+X-Purism-FormFactor=Workstation;Mobile;


### PR DESCRIPTION
Tangram is definitely a very mobile friendly application and should show up in [phosh](https://gitlab.gnome.org/World/Phosh/phosh) application menu as such. 

The extension to the .desktop file makes the application show in phosh (and possibly other shells that take notice of this setting) application list for applications that can be used on the phones screen (in contrast to other application that might only be usable when the mobile device is connected to an external monitor).