### PR TITLE
Enable live thumbnail for all tabs

### DIFF
--- a/src/tabs.js
+++ b/src/tabs.js
@@ -64,6 +64,7 @@ export function Tabs({
       webview.instance_id = instance.id;
 
       const tab_page = tab_view.append(webview);
+      tab_page.set_live_thumbnail(true);
 
       webview.bind_property(
         "favicon",


### PR DESCRIPTION
Without this, the thumbnail is refreshed only for the selected tab. It also causes that only the first thumbnail is visible when the application is launched. Setting the `live-thumbnail` property to `true` for all tabs solves the problem.

Reference: https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.TabOverview.html