### PR TITLE
WebView: Add null check for user download directory

### DIFF
--- a/src/WebView.js
+++ b/src/WebView.js
@@ -63,9 +63,8 @@ export function buildWebView({ instance, onNotification, window }) {
         suggested_filename = "";
       }
 
-      const dest_dir = Gio.File.new_for_path(
-        get_user_special_dir(UserDirectory.DIRECTORY_DOWNLOAD),
-      );
+      let download_dir = get_user_special_dir(UserDirectory.DIRECTORY_DOWNLOAD);
+      const dest_dir = download_dir ? Gio.File.new_for_path(download_dir) : null;
       const dialog = new Gtk.FileDialog({
         title: _("Save File"),
         initial_folder: dest_dir,


### PR DESCRIPTION
Ideally the download folder is always set, but we can't be sure, therefore add a null check.

Closes: https://github.com/sonnyp/Tangram/issues/321