### PR TITLE
refactor: incorrect url scheme detection in normalizeurl

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -52,11 +52,13 @@ export function isUrlAllowedForNavigation(webView, request_url) {
 export function normalizeURL(str) {
   if (!str) return null;
 
-  if (!str.startsWith("http")) {
-    str = "http://" + str;
+  let uri = GLib.Uri.parse(str, GLib.UriFlags.NONE);
+
+  // If parsing failed or no scheme, try prepending "http://"
+  if (!uri || !uri.get_scheme()) {
+    uri = GLib.Uri.parse("http://" + str, GLib.UriFlags.NONE);
   }
 
-  const uri = GLib.Uri.parse(str, GLib.UriFlags.NONE);
   if (!uri) return null;
 
   if (!["http", "https"].includes(uri.get_scheme())) {


### PR DESCRIPTION
### Problem

The `normalizeURL` function attempts to prepend "http://" if the input string does not start with "http". This logic is flawed because it can misinterpret hostnames that happen to start with a different scheme-like prefix (e.g., "ftp.example.com") as needing an "http://" prefix, leading to an incorrect URL like "http://ftp.example.com". It also fails to correctly handle URLs that already have a scheme but not "http" or "https" (e.g., "ftp://example.com") by attempting to prepend "http://" before the scheme check.

A more robust approach is to first attempt parsing the URL as-is. If it lacks a scheme, then prepend "http://" and try parsing again. Finally, validate that the resulting scheme is "http" or "https".


### Changes

The `normalizeURL` function attempts to prepend "http://" if the input string does not start with "http". This logic is flawed because it can misinterpret hostnames that happen to start with a different scheme-like prefix (e.g., "ftp.example.com") as needing an "http://" prefix, leading to an incorrect URL like "http://ftp.example.com". It also fails to correctly handle URLs that already have a scheme but not "http" or "https" (e.g., "ftp://example.com") by attempting to prepend "http://" before the scheme check.

A more robust approach is to first attempt parsing the URL as-is. If it lacks a scheme, then prepend "http://" and try parsing again. Finally, validate that the resulting scheme is "http" or "https".


**Modified files:**
- `src/utils.js` (modified)

### Checklist

- [x] Existing tests pass
- [x] Changes reviewed
- [x] No unrelated changes included
