### PR TITLE
webview: allow microphone and camera permission requests

### DIFF
--- a/src/WebView.js
+++ b/src/WebView.js
@@ -16,6 +16,7 @@ const {
   CookieAcceptPolicy,
   Settings,
   NotificationPermissionRequest,
+  UserMediaPermissionRequest,
   SecurityOrigin,
   UserContentManager,
   TLSErrorsPolicy,
@@ -135,6 +136,7 @@ export function buildWebView({ instance, onNotification, window }) {
   // https://gjs-docs.gnome.org/webkit240~4.0_api/webkit2.settings
   const settings = new Settings({
     enable_smooth_scrolling: true,
+    enable_media_stream: true,
     media_playback_requires_user_gesture: true,
 
     // https://gitlab.gnome.org/GNOME/epiphany/-/blob/master/embed/ephy-embed-prefs.c
@@ -184,6 +186,10 @@ export function buildWebView({ instance, onNotification, window }) {
     // https://gjs-docs.gnome.org/webkit240~4.0_api/webkit2.webview#signal-permission-request
     ["permission-request"](request) {
       if (request instanceof NotificationPermissionRequest) {
+        request.allow();
+        return;
+      }
+      if (request instanceof UserMediaPermissionRequest) {
         request.allow();
         return;
       }


### PR DESCRIPTION
Currently, the `permission-request` handler in WebView.js denies all
permission requests except notifications. This means that calls to
`getUserMedia()` (used by apps like WhatsApp Web for voice messages) are silently denied — no system dialog is shown to the user.

This patch:
- Imports `UserMediaPermissionRequest` from WebKit
- Adds `enable_media_stream: true` to WebKit settings
- Allows `UserMediaPermissionRequest` in the permission handler

Tested on Arch Linux with GNOME, using WhatsApp Web inside Tangram.
Microphone now works correctly after this change.